### PR TITLE
improve explanation && assert is_subset

### DIFF
--- a/src/wfc/collapse.rs
+++ b/src/wfc/collapse.rs
@@ -42,10 +42,13 @@ impl Collapse<'_> {
             else { heap.push(Observe::new_fuzz(rng, &from_index, labels, frequencies)) }
         }
 
-        // initialize propagates
+        // Ensure that output graph is fully propagated before starting loop.
+        // Generate Propagates for every vertex whose label set is a proper
+        // subset of the set of all labels.
         for (_index, labels) in vertices_iter {
             let from_index = _index as i32;
-            if labels != all_labels && labels.is_subset(all_labels) { // <-- labels is proper subset of all_labels
+            assert!(labels.is_subset(all_labels));
+            if labels != all_labels { // labels is proper subset of all_labels
                 generate_propagations(&mut propagations, &observed, &out_graph, &from_index);
             }
         }


### PR DESCRIPTION
I've added in an example assertion of an invariant. Since all vertex label sets are composed of only elements from the set of all labels it follows that all vertex label sets should be subsets of the set of all labels. So having the conditional check for is_subset is wasteful, instead this fact is clearly an invariant of our program.

I also added in some more detailed explanation of what we're doing in this part of the code.

I thought I'd make a PR for you as well just so we can try it out 😋 